### PR TITLE
Fixed 'Unknown option' error in foreman-host-configurator invocation script

### DIFF
--- a/foreman-host-configurator
+++ b/foreman-host-configurator
@@ -22,5 +22,5 @@ if [ ! -e "${SCRIPT_DIR}/target/foreman-host-configurator.jar" ] ; then
     fi
 fi
 
-$JAVACMD -jar "${SCRIPT_DIR}/target/foreman-host-configurator.jar" "$*"
+$JAVACMD -jar "${SCRIPT_DIR}/target/foreman-host-configurator.jar" "$@" 
 exit $?


### PR DESCRIPTION
Expanded:
`/usr/lib/jvm/java-1.8.0/bin/java -jar /home/pjanouse/devel/git/foreman-host-configurator/target/foreman-host-configurator.jar --debug list  --user=admin --password=changeme --server=http://10.8.182.9:32769/api` 
produces expected result

`/usr/lib/jvm/java-1.8.0/bin/java -jar /home/pjanouse/devel/git/foreman-host-configurator/target/foreman-host-configurator.jar '--debug list  --user=admin --password=changeme --server=http://10.8.182.9:32769/api'` 
produces:
"Unknown option: --debug list  --user=admin --password=changeme --server=http://10.8.182.9:32769/api"

I'm not 100% satisfied with this fix, we should use some form of quoting, but I don't know other way how to fix the current issue. From the shell PoV using double quotes is appropriate...