### PR TITLE
Modified searched exception text

### DIFF
--- a/src/test/java/com/scoheb/foreman/cli/MainTest.java
+++ b/src/test/java/com/scoheb/foreman/cli/MainTest.java
@@ -75,7 +75,7 @@ public class MainTest {
         exit.expectSystemExitWithStatus(1);
         exit.checkAssertionAfterwards(new Assertion() {
             public void checkAssertion() {
-                assertTrue(systemOutRule.getLog().indexOf("java.net.ConnectException: Connection refused (Connection refused)") >= 0);
+                assertTrue(systemOutRule.getLog().indexOf("java.net.ConnectException: Connection refused") >= 0);
             }
         });
         Main.main(new String[] {"list", "--server=http://127.0.0.1:9999",
@@ -87,7 +87,7 @@ public class MainTest {
         exit.expectSystemExitWithStatus(1);
         exit.checkAssertionAfterwards(new Assertion() {
             public void checkAssertion() {
-                assertTrue(systemOutRule.getLog().indexOf("java.net.ConnectException: Connection refused (Connection refused)") >= 0);
+                assertTrue(systemOutRule.getLog().indexOf("java.net.ConnectException: Connection refused") >= 0);
                 assertTrue(systemOutRule.getLog().indexOf("Debug logging enabled.") >= 0);
             }
         });


### PR DESCRIPTION
On my system the logged exception looks like:
> Debug logging enabled.
Listing ALL hosts:
java.net.ConnectException: Connection refused
javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused
        at org.glassfish.jersey.client.internal.HttpUrlConnector.apply(HttpUrlConnector.java:287)
.
.


[pjanouse@localhost foreman-host-configurator]$ java -version
openjdk version "1.8.0_45"
OpenJDK Runtime Environment (build 1.8.0_45-b14)
OpenJDK 64-Bit Server VM (build 25.45-b02, mixed mode)
